### PR TITLE
feat: custom port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN go build -o /someguy
 
 EXPOSE 8080
 
-CMD [ "/someguy", "start" ]
+CMD [ "/someguy", "start", "--port", "8080" ]

--- a/main.go
+++ b/main.go
@@ -17,8 +17,15 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name: "start",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "port",
+						Usage: "port to serve requests on",
+						Value: 8080,
+					},
+				},
 				Action: func(ctx *cli.Context) error {
-					return start(ctx.Context, 8080)
+					return start(ctx.Context, ctx.Int("port"))
 				},
 			},
 			{


### PR DESCRIPTION
Port 8080 no longer hard coded in the CLI, but it's currently left as the default and is made explicit in the Docker file.

Targeted after #6 